### PR TITLE
Handle undefined parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ var _ = require('lodash');
 function createSummary(summary) {
     // Filter the summary and kick out any failures found that have no parent defined (e.g failures issued from pre-request script execution)
     summary.run.failures.forEach(function(failure) {
+        console.log(`Scanning for Bad Parents.`)
         if (_.isUndefined(failure.parent)) {
+            console.log(`Bad Parent detected. Removing.`)
             _.pull(summary.run.failures, failure)
         }
     })

--- a/index.js
+++ b/index.js
@@ -16,21 +16,12 @@ var _ = require('lodash');
  */
 
 function createSummary(summary) {
-    // Filter the summary and kick out any failures found that have no parent defined (e.g failures issued from pre-request script execution)
-    // summary.run.failures.forEach(function(failure) {
-    //     console.log(`Scanning for Bad Parents.`)
-    //     if (_.isUndefined(failure.parent)) {
-    //         console.log(`Bad Parent detected. Removing.`)
-    //         _.pull(summary.run.failures, failure)
-    //     }
-    // })
 
+    //Strip out any errors with an undefined parent. For now these errors are dropped into the undefs array
+    //should we decide in the future that processing of them is also required.
     let undefs = _.remove(summary.run.failures, function(f) {
         return _.isUndefined(f.parent)
     })
-
-    console.log(`RUN FAILURES: ${summary.run.failures}`)
-    console.log(`UNDEFS${undefs}`)
 
     // Just pull out the miminum parts for each failure
     var failures = [];

--- a/index.js
+++ b/index.js
@@ -17,14 +17,20 @@ var _ = require('lodash');
 
 function createSummary(summary) {
     // Filter the summary and kick out any failures found that have no parent defined (e.g failures issued from pre-request script execution)
-    summary.run.failures.forEach(function(failure) {
-        console.log(`Scanning for Bad Parents.`)
-        if (_.isUndefined(failure.parent)) {
-            console.log(`Bad Parent detected. Removing.`)
-            _.pull(summary.run.failures, failure)
-        }
+    // summary.run.failures.forEach(function(failure) {
+    //     console.log(`Scanning for Bad Parents.`)
+    //     if (_.isUndefined(failure.parent)) {
+    //         console.log(`Bad Parent detected. Removing.`)
+    //         _.pull(summary.run.failures, failure)
+    //     }
+    // })
+
+    let undefs = _.remove(summary.run.failures, function(f) {
+        return _.isUndefined(f.parent)
     })
 
+    console.log(`RUN FAILURES: ${summary.run.failures}`)
+    console.log(`UNDEFS${undefs}`)
 
     // Just pull out the miminum parts for each failure
     var failures = [];

--- a/index.js
+++ b/index.js
@@ -16,7 +16,14 @@ var _ = require('lodash');
  */
 
 function createSummary(summary) {
-    
+    // Filter the summary and kick out any failures found that have no parent defined (e.g failures issued from pre-request script execution)
+    summary.run.failures.forEach(function(failure) {
+        if (_.isUndefined(failure.parent)) {
+            _.pull(summary.run.failures, failure)
+        }
+    })
+
+
     // Just pull out the miminum parts for each failure
     var failures = [];
     summary.run.failures.forEach(function(failure) {


### PR DESCRIPTION
Fix issue where the process of building failures array would fail when attempting to parse a failure that had no parent defined. Notable that these errors occur when a failure is found within the pre-request script.